### PR TITLE
fixed the display number to reflect only the sunflowers when plowed f…

### DIFF
--- a/src/Actions/ChooseComposter.cs
+++ b/src/Actions/ChooseComposter.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using Trestlebridge.Interfaces;
+using Trestlebridge.Models;
+using Trestlebridge.Models.Plants;
+using Trestlebridge.Models.Facilities;
+using System.Collections.Generic;
+
+namespace Trestlebridge.Actions {
+    public class ChooseComposter {
+
+        public static void CollectInput (Farm farm) {
+            Console.Clear();
+
+            for (int i = 0; i < farm.NaturalFields.Count; i++)
+                {
+                        Console.WriteLine($"{i + 1}. Natural Field ({farm.NaturalFields[i].plantsList.Count}) plants");
+                }
+
+                for (int i = 0; i < farm.PlowedFields.Count; i++)
+                {
+                         IEnumerable<ISeedProducing> sunflowersInPlowedField = from plant in farm.PlowedFields[i].plantsList
+                                where plant.Type == "Sunflower"
+                                select plant;
+
+                        Console.WriteLine($"{farm.NaturalFields.Count + i + 1}. Plowed Field ({sunflowersInPlowedField.Count()}) plants");
+
+                }
+
+                Console.WriteLine();
+
+                // How can I output the type of plant chosen here?
+                Console.WriteLine($"Which Facility would you like to process");
+
+                Console.Write("> ");
+                Console.ReadLine();
+            //     int choice = Int32.Parse(Console.ReadLine());
+            //     int correctedChoice = choice - 1;
+
+            //     if (farm.PlowedFields.Count == 0 && farm.NaturalFields.Count > 0)
+            //     {
+            //         farm.NaturalFields[correctedChoice].AddResource(farm, number, plantType);
+            //     }
+            //     else if (farm.NaturalFields.Count == 0 && farm.PlowedFields.Count > 0)
+            //     {
+            //         farm.PlowedFields[correctedChoice].AddResource(farm, number, plantType);
+            //     }
+            //     else if (correctedChoice >= farm.PlowedFields.Count)
+            //     {
+            //         farm.NaturalFields[correctedChoice - farm.PlowedFields.Count].AddResource(farm, number, plantType);
+            //     }
+            //     else if (correctedChoice < farm.PlowedFields.Count)
+            //     {
+            //         farm.PlowedFields[correctedChoice].AddResource(farm, number, plantType);
+            //     }
+
+            // farm.NaturalFields[correctedChoice].AddResource(farm, number, plantType);
+
+            //runs the code if you don't need the at capacity message
+
+        }
+    }
+}

--- a/src/Actions/ChooseProcessingOption.cs
+++ b/src/Actions/ChooseProcessingOption.cs
@@ -22,9 +22,12 @@ namespace Trestlebridge.Actions
 
             switch (Int32.Parse(choice))
                 {
-                  
+                    
                     case 2:
                         ChooseMeatProcessor.CollectInput(farm);
+                        break;
+                    case 4:
+                        ChooseComposter.CollectInput(farm);
                         break;
                     default:
                         break;


### PR DESCRIPTION

# Description
Display ONLY the sunflowers in the number of 'processable' product in the field when on the choose facility menu of chooseComposter

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing Instructions for Change Made
1. `git fetch --all`
1. `git checkout choosecomposter
1. dotnet run
1. verify... add plowed fields and wild fields, add both sunflower and sesame to the plowed fields, when you process with the composter, the number shown should reflect only the sunflowers, because they are the only ones that can be processed for compost 


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works

